### PR TITLE
Changes keyboard event handler to keydown

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -151,7 +151,7 @@ function handleKeyPress(e) {
 	try {
 		shiftNextKey(e.key)
 	} catch (e: StatusUpdate) {
-		window.document.removeEventListener('keyup', handleKeyPress)
+		window.document.removeEventListener('keydown', handleKeyPress)
 
 		endSession()
 		console.log('Error: ', e)
@@ -274,7 +274,7 @@ function main() {
 	// Initialize current selected
 	window.document.querySelector('pre span.initial').classList.add('active')
 
-	window.document.addEventListener('keyup', handleKeyPress)
+	window.document.addEventListener('keydown', handleKeyPress)
 }
 
 main()


### PR DESCRIPTION
I changed the keyboard event listener to keydown rather than keyup. Not only did it resolve the bug in issue #1, but it also improved the perceived performance. Previously, I felt a little bit of lag when typing since it was waiting for the key to be released, but now the typing experience feels way nicer.